### PR TITLE
Wiki issues

### DIFF
--- a/PABatchTool.m
+++ b/PABatchTool.m
@@ -29,6 +29,14 @@ classdef PABatchTool < handle
         isRunning;
     end
     
+    methods(Access=private)
+        function disable(this)
+            disablehandles(this.figureH);
+        end
+        function enable(this)
+            enablehandles(this.figureH);
+        end
+    end
     methods
         
         %> @brief Class constructor.
@@ -193,6 +201,7 @@ classdef PABatchTool < handle
         % --------------------------------------------------------------------        
         function startBatchProcessCallback(obj,hObject,eventdata)
                         
+            obj.disable();
             dateMap.Sun = 0;
             dateMap.Mon = 1;
             dateMap.Tue = 2;
@@ -209,6 +218,7 @@ classdef PABatchTool < handle
             
             % Get batch processing settings from the GUI     
             handles = guidata(hObject);
+            
             
             obj.notify('BatchToolStarting',EventData_BatchTool(obj.settings));
             accelType = 'count';
@@ -539,6 +549,7 @@ classdef PABatchTool < handle
             end
             
             obj.isRunning = false;
+            obj.enable();
             
             %             obj.resultsPathname = obj.settings.outputDirectory;
         end

--- a/PAController.m
+++ b/PAController.m
@@ -858,6 +858,8 @@ classdef PAController < handle
             selectionIndex = find(strcmpi(signalTagLines,signalTagLine)) ;
             if(isempty(selectionIndex))
                 selectionIndex = 1;
+                signalTagLine = signalTagLines{selectionIndex};
+                
             end
             
             set(obj.VIEW.menuhandle.signalSelection,'value',selectionIndex);
@@ -871,6 +873,8 @@ classdef PAController < handle
                     obj.accelTypeShown = v{1}{1};
                 end                
             end
+            
+            %             obj.SETTINGS.CONTROLLER.signalTagLine = signalTagLine;
         end
         
         % --------------------------------------------------------------------
@@ -2389,7 +2393,6 @@ classdef PAController < handle
             featureFcns = fieldnames(featureStruct);
             pStruct.featureFcn = featureFcns{1};
             pStruct.signalTagLine = tagLines{1};
-
             
             mPath = fileparts(mfilename('fullpath'));
             pStruct.screenshotPathname = mPath;

--- a/PAController.m
+++ b/PAController.m
@@ -2111,6 +2111,13 @@ classdef PAController < handle
         function pStruct = getSaveParameters(obj)
             pStruct.featureFcn = obj.getExtractorMethod();
             pStruct.signalTagLine = obj.getSignalSelection();
+            
+            % If we did not load a file then our signal selection will be
+            % empty (don't know if were going to use count or raw data,
+            % etc.  So, just stick with whatever we began with at time of construction.
+            if(isempty(pStruct.signalTagLine))
+                pStruct.signalTagLine = obj.SETTINGS.CONTROLLER.signalTagLine;                
+            end
             pStruct.screenshotPathname = obj.screenshotPathname;
             pStruct.viewMode = obj.viewMode;
             pStruct.resultsPathname = obj.resultsPathname;

--- a/PAData.m
+++ b/PAData.m
@@ -1658,9 +1658,12 @@ classdef PAData < handle
                 % otherwise just use the original
             end
             
-            data = obj.getStruct('all');
-            data = eval(['data.',signalTagLine]);
-            
+            try
+                data = obj.getStruct('all');
+                data = eval(['data.',signalTagLine]);
+            catch me                
+                rethrow(me);  %this is just for debugging.
+            end
             obj.frames =  reshape(data(1:frameableSamples),[],obj.numFrames);  %each frame consists of a column of data.  Consecutive columns represent consecutive frames.
             % Frames are stored in consecutive columns.  Thus the rows
             % represent the consecutive samples of data for that frame
@@ -2714,14 +2717,15 @@ classdef PAData < handle
         %> structs returned by getStruct.
         %======================================================================
         function [tagLines,labels] = getDefaultTagLineLabels()
-            tagLines = {'accel.raw.x';
+            tagLines = {
+                'accel.raw.vecMag';
+                'accel.raw.x';
                 'accel.raw.y';
                 'accel.raw.z';
-                'accel.raw.vecMag';
+                'accel.count.vecMag';
                 'accel.count.x';
                 'accel.count.y';
                 'accel.count.z';
-                'accel.count.vecMag';
                 'steps';
                 'lux';
                 'inclinometer.standing';
@@ -2729,14 +2733,15 @@ classdef PAData < handle
                 'inclinometer.lying';
                 'inclinometer.off';
                 };
-            labels = {'X (raw)';
+            labels = {
+                'Magnitude (raw)';
+                'X (raw)';
                 'Y (raw)';
                 'Z (raw)';
-                'Magnitude (raw)';
+                'Magnitude (count)';
                 'X (count)';
                 'Y (count)';
                 'Z (count)';
-                'Magnitude (count)';
                 'Steps';
                 'Luminance'
                 'inclinometer.standing';

--- a/PASettings.m
+++ b/PASettings.m
@@ -19,9 +19,9 @@ classdef  PASettings < handle
         %> is useful when saving the setting's file to make sure it is
         %> always saved in the same place and not in another directory
         %> (e.g. if the user moves about in MATLAB's editor).
-        rootpathname
+        rootpathname;
         %> @brief name of text file that stores the toolkit's settings
-        parameters_filename
+        parameters_filename;
         %> @brief cell of string names corresponding to the struct properties that
         %> contain settings  <b><i> {'DATA','VIEW', 'CONTROLLER','BATCH'}</i></b>
         fieldNames;
@@ -356,6 +356,9 @@ classdef  PASettings < handle
                     fprintf('\nWarning: Could not load parameters from file %s.  Will use default settings instead.\n\r',full_paramsFile);
                     
                 else
+                    % Here we go now...
+                    % obj = PAData.mergeStruct(obh,paramStruct);
+                    
                     fnames = fieldnames(paramStruct);
                     
                     if(isempty(fnames))
@@ -375,12 +378,16 @@ classdef  PASettings < handle
                                     if(~isfield(paramStruct.(cur_field),cur_sub_field))
                                         fprintf('\nSettings file may be corrupted or incomplete.  The %s.%s parameter is missing.  Using default setting for this paramter.\n\n', cur_field,cur_sub_field);
                                         continue;
+                                    elseif(isempty(paramStruct.(cur_field).(cur_sub_field)))
+                                        fprintf('\nSettings file may be corrupted or incomplete.  The %s.%s parameter is empty ('').  Using default setting for this paramter instead.\n\n', cur_field,cur_sub_field);
+                                        paramStruct.(cur_field).(cur_sub_field) = obj.(cur_field).(cur_sub_field);  % We'll take whatever came up from obj.setDefaults();
+                                        continue;
                                     end
                                 end
                             end
                         end
                         
-                        % Not that everything has been checked and we have
+                        % Now that everything has been checked and we have
                         % warned the groups of what we may be missing, we
                         % can continue.
                         for f=1:numel(fnames)

--- a/PASettings.m
+++ b/PASettings.m
@@ -379,7 +379,7 @@ classdef  PASettings < handle
                                         fprintf('\nSettings file may be corrupted or incomplete.  The %s.%s parameter is missing.  Using default setting for this paramter.\n\n', cur_field,cur_sub_field);
                                         continue;
                                     elseif(isempty(paramStruct.(cur_field).(cur_sub_field)))
-                                        fprintf('\nSettings file may be corrupted or incomplete.  The %s.%s parameter is empty ('').  Using default setting for this paramter instead.\n\n', cur_field,cur_sub_field);
+                                        fprintf('\nSettings file may be corrupted or incomplete.  The %s.%s parameter is empty ('''').  Using default setting for this paramter instead.\n\n', cur_field,cur_sub_field);
                                         paramStruct.(cur_field).(cur_sub_field) = obj.(cur_field).(cur_sub_field);  % We'll take whatever came up from obj.setDefaults();
                                         continue;
                                     end

--- a/utility/enablehandles.m
+++ b/utility/enablehandles.m
@@ -1,0 +1,5 @@
+%> @brief Utility method to disable graphic handles at and below the handle
+%> parameter passed.
+function enablehandles(handles)
+    sethandles(handles,'enable','on');
+end

--- a/utility/sethandles.m
+++ b/utility/sethandles.m
@@ -1,0 +1,11 @@
+%> @brief Utility method to set the property value for one or more handles and their descendents
+%> as applicable.  If a handle does not have the property, nothing is done
+%> for it, but its descendants are still examined for the property and set
+%> where applicable.
+function sethandles(handles, property, value)
+    if(all(ishandle(handles)))
+        for n=1:numel(handles)
+            set(findobj(handles(n),'-property',property),property,value);
+        end
+    end
+end


### PR DESCRIPTION
If data was not loaded then the signal tag line was not initialized and
thus empty when the program closed.  This caused the previous signal
tag line identifier to be removed and reset (to the default) the next
time padaco was run.
