### PR TITLE
Making code deployable.

### DIFF
--- a/+featureFcn/getpsd.m
+++ b/+featureFcn/getpsd.m
@@ -88,7 +88,17 @@ function [psd_vec, freq_vec, nfft] = getpsd(signal_x,Fs,PSD_settings,ZeroPad)
         end
         % win = window(eval(['@' wintype]),nfft);
         % win = eval([wintype '(' num2str(nfft) ')']);
-        win = window(wintype,nfft);
+        
+        % for some reason, I cannot get hann to show up in the deployed
+        % version.  Most likely, I will need to add other methods like this
+        % manually with the deploytool application compiler.
+        if(strcmpi(wintype,'hann'))
+            win = hann(nfft);
+        else
+            win = window(wintype,nfft);
+        end
+        
+        
         U = win'*win;  %Window normalization
         
         % Calculate the numberof unique points

--- a/deploySetup.m
+++ b/deploySetup.m
@@ -7,4 +7,4 @@ for s=1:numel(subPaths)
     addpath(fullfile(mPathname,subPaths{s}));
 end
 
-deploytool
+applicationCompiler


### PR DESCRIPTION
Compiled version kept looking for ‘hand’ function.  Because this method
is not explicitly called, it is not brought into the compilation and
the data files are not able to complete their processing.
